### PR TITLE
(#105) Fix org-cliplink-retrieve-title-synchronous

### DIFF
--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -517,11 +517,12 @@ Used when the current transport implementation is set to
 
 ;;;###autoload
 (defun org-cliplink-retrieve-title-synchronously (url)
-  (let ((response-buffer (url-retrieve-synchronously url)))
-    (if response-buffer
-      (with-current-buffer response-buffer
-        (org-cliplink-extract-and-prepare-title-from-current-buffer))
-      (message "Response buffer is nil!"))))
+  (when (member (url-type (url-generic-parse-url url))
+                '("http" "https"))
+    (let ((response-buffer (url-retrieve-synchronously url t)))
+      (when response-buffer
+        (with-current-buffer response-buffer
+          (org-cliplink-extract-and-prepare-title-from-current-buffer))))))
 
 ;;;###autoload
 (defun org-cliplink ()

--- a/test/org-cliplink-test.el
+++ b/test/org-cliplink-test.el
@@ -113,3 +113,9 @@
   (kill-append "khooy" nil)
   (should (equal "khooy"
                  (org-cliplink-clipboard-content))))
+
+(ert-deftest org-cliplink-retrieve-title-synchronously-test ()
+  (with-mock
+   (stub message => :times 0)
+   (should (equal nil
+                  (org-cliplink-retrieve-title-synchronously "file:///.")))))


### PR DESCRIPTION
- Make it silent.
- Support only http and https. Reject any other protocols.

As per #105 