### PR TITLE
Trim whitespace from URLs

### DIFF
--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -50,6 +50,7 @@
 ;;; Code:
 
 (require 'em-glob)
+(require 'subr-x) ; for string-trim
 
 (require 'org-cliplink-string)
 (require 'org-cliplink-transport)
@@ -430,7 +431,8 @@ When nil, use the first element of kill-ring as source"
                           (fboundp 'simpleclip-get-contents))
                      (simpleclip-get-contents)
                    (current-kill 0))))
-    (substring-no-properties content)))
+    (string-trim
+     (substring-no-properties content))))
 
 (defun org-cliplink-parse-raw-header (raw-header)
   (let ((start 0)


### PR DESCRIPTION
* `org-cliplink.el` (`org-cliplink-clipboard-content`): Trim the string.

--- 

I assume there is no need to make this configurable since a URL cannot contain whitespace.

I'm ambivalent about whether trimming should be done by `org-cliplink-clipboard-content`, by `org-cliplink-org-mode-link-transformer`, or possibly by `org-cliplink` and `org-cliplink-capture`.  What do you think?
