### PR TITLE
Allow truncation to be disabled

### DIFF
--- a/org-cliplink-string.el
+++ b/org-cliplink-string.el
@@ -6,11 +6,13 @@
   (mapconcat #'identity ss " "))
 
 (defun org-cliplink-elide-string (s max-length)
-  (when s
-    (if (> max-length 3)
-        (if (> (length s) max-length)
-            (concat (substring s 0 (- max-length 3)) "...")
-          s)
-      "...")))
+  (if max-length
+      (when s
+        (if (> max-length 3)
+            (if (> (length s) max-length)
+                (concat (substring s 0 (- max-length 3)) "...")
+              s)
+          "..."))
+    s))
 
 (provide 'org-cliplink-string)

--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -380,7 +380,7 @@ buffer."
 Org-cliplink cuts any title that exceeds the limit. Minimum
 possible value is 4."
   :group 'org-cliplink
-  :type 'integer)
+  :type '(choice integer (const :tag "off" nil)))
 
 (defcustom org-cliplink-secrets-path "~/.org-cliplink-secrets.el"
   "Path to file that keeps your org-cliplink related secrets.

--- a/test/org-cliplink-string-test.el
+++ b/test/org-cliplink-string-test.el
@@ -1,5 +1,8 @@
 (ert-deftest org-cliplink-elide-string-test ()
   (should (not (org-cliplink-elide-string nil 0)))
+  (let ((max-length nil)
+        (long-string (make-string 1000 ?x)))
+    (should (equal long-string (org-cliplink-elide-string long-string max-length))))
   (let ((max-length 5))
     (should (equal "test" (org-cliplink-elide-string "test" max-length)))
     (should (equal "hello" (org-cliplink-elide-string "hello" max-length)))


### PR DESCRIPTION
* `org-cliplink-string.el` (`org-cliplink-elide-string`): Return the string without truncation if `max-length` is nil.
* `org-cliplink.el` (`org-cliplink-max-length`): Change type to a choice of integer or nil.
* `test/org-cliplink-string-test.el` (`org-cliplink-elide-string-test`): Add test case with no max length.