### PR TITLE
Allow changing the ellipsis used at the end of truncated urls

### DIFF
--- a/org-cliplink-string.el
+++ b/org-cliplink-string.el
@@ -5,14 +5,15 @@
 (defun org-cliplink-join-string (ss)
   (mapconcat #'identity ss " "))
 
+(setq org-cliplink-ellipsis "...")
 (defun org-cliplink-elide-string (s max-length)
   (if max-length
       (when s
         (if (> max-length 3)
             (if (> (length s) max-length)
-                (concat (substring s 0 (- max-length 3)) "...")
+                (concat (substring s 0 (- max-length 3)) org-cliplink-ellipsis)
               s)
-          "..."))
+          org-cliplink-ellipsis))
     s))
 
 (provide 'org-cliplink-string)

--- a/org-cliplink-string.el
+++ b/org-cliplink-string.el
@@ -5,7 +5,6 @@
 (defun org-cliplink-join-string (ss)
   (mapconcat #'identity ss " "))
 
-(setq org-cliplink-ellipsis "...")
 (defun org-cliplink-elide-string (s max-length)
   (if max-length
       (when s

--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -383,6 +383,11 @@ possible value is 4."
   :group 'org-cliplink
   :type '(choice integer (const :tag "off" nil)))
 
+(defcustom org-cliplink-ellipsis "..."
+  "String to mark the end of truncated titles"
+  :group 'org-cliplink
+  :type 'string)
+
 (defcustom org-cliplink-secrets-path "~/.org-cliplink-secrets.el"
   "Path to file that keeps your org-cliplink related secrets.
 It can be any sensitive information like password to different


### PR DESCRIPTION
It should be up to the user to decide what the ellipsis looks like, instead of it being hardcoded. For example, I made this commit so I could set the ellipsis to be the unicode character `…` instead of `...`, in my personal configuration, because I find it more elegant. The previous default remains unchanged. This is only an option for customization.