### PR TITLE
Save marker and use it in callback for insert

### DIFF
--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -559,10 +559,18 @@ TITLE-REGEXP does not match TITLE, return the original TITLE."
   "Takes the URL, asynchronously retrieves the title and applies
 a custom TRANSFORMER which transforms the url and title and insert
 the required text to the current buffer."
-  (org-cliplink-retrieve-title
-   url
-   (lambda (url title)
-     (insert (funcall transformer url title)))))
+  (let ((m (point-marker)))
+    (org-cliplink-retrieve-title
+     url
+     (lambda (url title)
+       (let ((save-and-restore-position (/= (point) m))
+             (link (funcall transformer url title)))
+         (if save-and-restore-position
+             (save-excursion
+               (goto-char m)
+               (insert link))
+           (insert link))
+         (set-marker m nil))))))
 
 ;;;###autoload
 (defun org-cliplink-retrieve-title-synchronously (url)

--- a/org-cliplink.el
+++ b/org-cliplink.el
@@ -500,9 +500,6 @@ TITLE-REGEXP does not match TITLE, return the original TITLE."
                                 org-cliplink-max-length))
     (format "[[%s]]" url)))
 
-(defun org-cliplink-insert-org-mode-link-callback (url title)
-  (insert (org-cliplink-org-mode-link-transformer url title)))
-
 (defun org-cliplink-uncompress-gziped-text (text)
   (let ((filename (make-temp-file "org-cliplink" nil ".gz")))
     (write-region text nil filename)

--- a/test/org-cliplink-test.el
+++ b/test/org-cliplink-test.el
@@ -90,15 +90,6 @@
                   "&amp;[Hello] &#39;[World] &alpha; &nbsp;")))
   (should (not (org-cliplink-escape-html4 nil))))
 
-(ert-deftest org-cliplink-insert-org-mode-link-callback-test ()
-  (with-temp-buffer
-    (org-cliplink-insert-org-mode-link-callback "http://google.com/" "Google")
-    (should (equal (buffer-string) "[[http://google.com/][Google]]")))
-
-  (with-temp-buffer
-    (org-cliplink-insert-org-mode-link-callback "http://google.com" nil)
-    (should (equal (buffer-string) "[[http://google.com]]"))))
-
 (ert-deftest org-cliplink-uncompress-gziped-text-test ()
   (let ((gziped-content (concat "\x1F\x8B\x08\x00\xD8\x8B"
                                 "\x74\x55\x00\x03\xCB\x48"


### PR DESCRIPTION
#### Delete unused callback function

Follow-up to commit 666d0cdf0cc6ea120c83b190396d76f0ac32605a.

* `org-cliplink.el` (`org-cliplink-insert-org-mode-link-callback`): Delete function.
* `test/org-cliplink-test.el` (`org-cliplink-insert-org-mode-link-callback-test`): Delete test.


#### Save marker and use it in callback for insert

* `org-cliplink.el` (`org-cliplink-insert-transformed-title`): Save point as a marker, and use it in the callback so that it inserts the link at the position at which the `org-cliplink` command was executed.


---

@rexim, I believe this fixes #22 and obviates #55.