### PR TITLE
Replace `cl` with `cl-lib`

### DIFF
--- a/curl-integration-tests.el
+++ b/curl-integration-tests.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t -*-
+
 (require 'ert)
 
 (add-to-list 'load-path ".")

--- a/test/org-cliplink-string-test.el
+++ b/test/org-cliplink-string-test.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t -*-
+
 (ert-deftest org-cliplink-elide-string-test ()
   (should (not (org-cliplink-elide-string nil 0)))
   (let ((max-length nil)

--- a/test/org-cliplink-test.el
+++ b/test/org-cliplink-test.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t -*-
+
 (ert-deftest org-cliplink-parse-raw-header-test ()
   (should (equal
            '(("Last-Modified" . "Sun, 08 Mar 2015 14:06:08 GMT")

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,4 +1,6 @@
-(require 'cl)
+;;; -*- lexical-binding: t -*-
+
+(require 'cl-lib)
 (require 'el-mock)
 (require 'undercover)
 

--- a/url-el-integration-tests.el
+++ b/url-el-integration-tests.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t -*-
+
 (require 'ert)
 
 (add-to-list 'load-path ".")


### PR DESCRIPTION
Package `cl` is deprecated and generates a warning in Emacs 27